### PR TITLE
Make min-max range inclusive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,11 @@
-sudo: false
 language: java
+
+dist: xenial
+
+jdk:
+  # - openjdk11
+  - openjdk8
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/pkg-java/pom.xml
+++ b/pkg-java/pom.xml
@@ -25,6 +25,7 @@
     <properties>
         <project.build.source>1.8</project.build.source>
         <project.build.target>1.8</project.build.target>
+        <xmlunit.version>2.6.2</xmlunit.version>
     </properties>
 
     <dependencies>
@@ -33,6 +34,18 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-core</artifactId>
+            <version>${xmlunit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>org.xmlunit</groupId>-->
+            <!--<artifactId>xmlunit-matchers</artifactId>-->
+            <!--<version>${xmlunit.version}</version>-->
+            <!--<scope>test</scope>-->
+        <!--</dependency>-->
     </dependencies>
 
 </project>

--- a/pkg-java/src/main/java/org/expath/pkg/repo/deps/DepSemverMinMax.java
+++ b/pkg-java/src/main/java/org/expath/pkg/repo/deps/DepSemverMinMax.java
@@ -13,8 +13,9 @@ import org.expath.pkg.repo.PackageException;
 
 /**
  * A dependency version using {@code @semver-min} and {@code @semver-max}.
- * 
+ *
  * @author Florent Georges
+ * @author Duncan Paterson
  */
 class DepSemverMinMax
         extends DependencyVersion
@@ -31,7 +32,7 @@ class DepSemverMinMax
             throws PackageException
     {
         Semver rhs = Semver.parse(version);
-        return myMin.matchesMin(rhs) && myMax.matchesMax(rhs) && !myMax.matches(rhs);
+        return myMin.matchesMin(rhs) && myMax.matchesMax(rhs);
     }
 
     private Semver myMin;

--- a/pkg-java/src/test/java/org/expath/pkg/repo/deps/DepSemverMinMaxTest.java
+++ b/pkg-java/src/test/java/org/expath/pkg/repo/deps/DepSemverMinMaxTest.java
@@ -1,0 +1,84 @@
+package org.expath.pkg.repo.deps;
+
+import org.expath.pkg.repo.PackageException;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests of {@code DepSemverMinMax}.
+ *
+ * @author Duncan Paterson
+ */
+public class DepSemverMinMaxTest {
+    @Test
+    public void testMatchesRange_1() throws PackageException {
+    final String min = "0.9.9";
+    final String max = "1.1.0";
+    final String myVersion = "1.0.0";
+
+    final boolean result = new DepSemverMinMax(min, max).isCompatible(myVersion);
+    assertTrue("myVersion is within range", result);
+    }
+
+    @Test
+    public void testMatchesRange_2() throws PackageException {
+        final String min = "1.0.0";
+        final String max = "1.1.0";
+        final String myVersion = "1.0.0";
+
+        final boolean result = new DepSemverMinMax(min, max).isCompatible(myVersion);
+        assertTrue("myVersion is min inclusive", result);
+    }
+
+    @Test
+    public void testMatchesRange_3() throws PackageException {
+        final String min = "0.9.9";
+        final String max = "1.0.0";
+        final String myVersion = "1.0.0";
+
+        final boolean result = new DepSemverMinMax(min, max).isCompatible(myVersion);
+        assertTrue("myVersion is max inclusive", result);
+    }
+
+    @Test
+    public void testMatchesRange_4() throws PackageException {
+        final String min = "0.9.9";
+        final String max = "1.1.0";
+        final String myVersion = "1.2.0";
+
+        final boolean result = new DepSemverMinMax(min, max).isCompatible(myVersion);
+        assertFalse("myVersion is not within range", result);
+    }
+
+    @Test
+    public void testMatchesRange_5() throws PackageException {
+        final String min = "0.9.0";
+        final String max = "1.0.0-RC1";
+        final String myVersion = "1.0.0";
+
+        final boolean result = new DepSemverMinMax(min, max).isCompatible(myVersion);
+        assertFalse("rc is not within range of non-rc", result);
+    }
+
+    @Test
+    public void testMatchesRange_6() throws PackageException {
+        final String min = "0.9.0";
+        final String max = "1.0.0";
+        final String myVersion = "1.0.0-SNAPSHOT";
+
+        final boolean result = new DepSemverMinMax(min, max).isCompatible(myVersion);
+        assertTrue("Snapshot is within range", result);
+    }
+
+    @Test
+    public void testMatchesRange_7() throws PackageException {
+        final String min = "0.9.0-SNAPSHOT";
+        final String max = "1.0.0-RC1";
+        final String myVersion = "1.0.0-SNAPSHOT";
+
+        final boolean result = new DepSemverMinMax(min, max).isCompatible(myVersion);
+        assertFalse("Snapshot is not within range", result);
+    }
+}
+

--- a/pkg-java/src/test/java/org/expath/pkg/repo/deps/SemverTest.java
+++ b/pkg-java/src/test/java/org/expath/pkg/repo/deps/SemverTest.java
@@ -336,6 +336,16 @@ public class SemverTest
         boolean result = template.matchesMax(version);
         assertTrue("the version matches the template as maximum", result);
     }
+
+    @Test
+    public void testMatchesMinMax() throws PackageException
+    {
+        Semver template = Semver.parse("1.2.3-alpha");
+        Semver version = Semver.parse("1.2.3-alpha");
+        final boolean result = template.matchesMax(version) && template.matchesMin(version);
+        assertTrue("the version matches the template as maximum", result);
+    }
+
 }
 
 


### PR DESCRIPTION
java11 is disabled for now … lots of javadocs errors when trying to build this … other test failures on 11 due to regex parsing of xml. 

see eXist-db/exist#2449
see eXist-db/monex#76
